### PR TITLE
refactor(timeline): add virtualization on timeline column

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
         "@mui/icons-material": "^5.13.7",
         "@mui/lab": "^5.0.0-alpha.135",
         "@mui/material": "^5.13.6",
+        "@tanstack/react-virtual": "^3.0.0-beta.54",
         "dayjs": "^1.11.9",
         "is-url": "^1.2.4",
         "lodash": "^4.17.21",

--- a/apps/web/src/components/Column/Base.styles.tsx
+++ b/apps/web/src/components/Column/Base.styles.tsx
@@ -67,12 +67,6 @@ export const Handle = styled.button`
     }
 `;
 
-export const Body = styled.div`
-    position: relative;
-
-    overflow-y: auto;
-`;
-
 export const Content = styled.div`
     height: 100%;
 

--- a/apps/web/src/components/Column/Base.tsx
+++ b/apps/web/src/components/Column/Base.tsx
@@ -8,19 +8,21 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
 import { ColumnInstance } from "@components/Column/types";
-import { Body, Content, Handle, Header, ProgressWrapper, Root } from "@components/Column/Base.styles";
+import { Content, Handle, Header, ProgressWrapper, Root } from "@components/Column/Base.styles";
 
 import { useColumnNodeSetter } from "@states/columns";
+import { Fn } from "@utils/types";
 
 export interface ColumnProps {
     instance: ColumnInstance;
-    children: React.ReactNode;
+    children: React.ReactNode | Fn<[view: HTMLElement | null], React.ReactNode>;
     loading?: boolean;
     onScroll?: (offset: number) => void;
 }
 
 export const BaseColumn = ({ instance, children, loading, onScroll }: ColumnProps) => {
     const { id, title } = instance;
+    const [scrollbars, setScrollbars] = React.useState<Scrollbars | null>(null);
     const setColumnNode = useColumnNodeSetter(id);
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
         id,
@@ -55,8 +57,9 @@ export const BaseColumn = ({ instance, children, loading, onScroll }: ColumnProp
                 <ProgressWrapper style={{ opacity: loading ? 1 : 0 }}>
                     <LinearProgress />
                 </ProgressWrapper>
-                <Scrollbars autoHide onScroll={handleScroll}>
-                    <Body>{children}</Body>
+                <Scrollbars ref={setScrollbars} autoHide onScroll={handleScroll}>
+                    {typeof children === "function" && children(scrollbars?.view ?? null)}
+                    {typeof children !== "function" && children}
                 </Scrollbars>
             </Content>
         </Root>

--- a/apps/web/src/components/Column/TimelineColumn.tsx
+++ b/apps/web/src/components/Column/TimelineColumn.tsx
@@ -31,7 +31,7 @@ export function TimelineColumn({ instance }: TimelineColumnProps) {
         <TimelineSubscription timeline={timeline} shouldTrim={scrollPosition === 0}>
             {(items, loading) => (
                 <BaseColumn loading={loading} instance={instance} onScroll={setScrollPosition}>
-                    <Timeline items={items} />
+                    {view => <Timeline items={items} scrollElement={view} />}
                 </BaseColumn>
             )}
         </TimelineSubscription>

--- a/apps/web/src/components/Timeline/Item.tsx
+++ b/apps/web/src/components/Timeline/Item.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import useMeasure from "react-use-measure";
 import { Avatar } from "ui";
 
 import dayjs from "dayjs";
@@ -37,13 +38,23 @@ dayjs.updateLocale("en", {
 
 export interface TimelineItemProps {
     item: TimelineItem;
+    onHeightChange?: (height: number) => void;
 }
 
-export const TimelineItemView = React.memo(({ item }: TimelineItemProps) => {
+export const TimelineItemView = React.memo(({ item, onHeightChange }: TimelineItemProps) => {
+    const [measureRef, { height }] = useMeasure();
     const { avatarUrl, content, accountName, accountId, instanceUrl, createdAt, attachments } = item;
 
+    React.useEffect(() => {
+        if (!height) {
+            return;
+        }
+
+        onHeightChange?.(height);
+    }, [height]);
+
     return (
-        <Root>
+        <Root ref={measureRef}>
             <Header>
                 <Avatar size="small" src={avatarUrl} sx={{ flex: "0 0 auto" }} />
                 <Box minWidth={0} display="flex" flex="1 1 auto">

--- a/apps/web/src/components/Timeline/index.styles.tsx
+++ b/apps/web/src/components/Timeline/index.styles.tsx
@@ -20,3 +20,14 @@ export const Content = styled.div`
     top: 0;
     left: 0;
 `;
+
+export const CacheRenderer = styled.div`
+    position: fixed;
+    top: 0;
+    right: 0;
+
+    z-index: 500000;
+
+    pointer-events: none;
+    visibility: hidden;
+`;

--- a/apps/web/src/components/Timeline/index.styles.tsx
+++ b/apps/web/src/components/Timeline/index.styles.tsx
@@ -7,5 +7,16 @@ export const Root = styled.div`
     margin: 0;
     padding: 0;
 
+    position: relative;
+
     overflow-x: hidden;
+    overflow-y: hidden;
+`;
+
+export const Content = styled.div`
+    width: 100%;
+
+    position: absolute;
+    top: 0;
+    left: 0;
 `;

--- a/apps/web/src/components/Timeline/index.tsx
+++ b/apps/web/src/components/Timeline/index.tsx
@@ -1,10 +1,13 @@
+import _ from "lodash";
+
 import React from "react";
+import useMeasure from "react-use-measure";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { TimelineItem } from "@services/base/timeline";
 
 import { TimelineItemView } from "@components/Timeline/Item";
-import { Content, Root } from "@components/Timeline/index.styles";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { CacheRenderer, Content, Root } from "@components/Timeline/index.styles";
 
 export interface TimelineProps {
     items: TimelineItem[];
@@ -12,22 +15,63 @@ export interface TimelineProps {
 }
 
 export function Timeline({ items, scrollElement }: TimelineProps) {
+    const [measureRef, { width }] = useMeasure();
+    const heightMap = React.useRef<Record<string, number>>({});
+    const lastHeight = React.useRef<number>(0);
+    const [cachedItems, setCachedItems] = React.useState<TimelineItem[]>(items);
+    const [itemsToMeasure, setItemsToMeasure] = React.useState<TimelineItem[]>([]);
     const virtualizer = useVirtualizer({
-        estimateSize: () => 200,
+        estimateSize: idx => heightMap.current[cachedItems[idx].id] ?? 200,
         getScrollElement: () => scrollElement ?? null,
-        count: items.length,
-        getItemKey: index => items[index].id,
+        count: cachedItems.length,
+        getItemKey: index => cachedItems[index].id,
     });
 
     const virtualizedItems = virtualizer.getVirtualItems();
+    const totalSize = virtualizer.getTotalSize();
+
+    React.useEffect(() => {
+        const scrollHeight = virtualizer.getTotalSize();
+        const scrollY = scrollElement?.scrollTop ?? 0;
+        if (scrollHeight === lastHeight.current || scrollY === 0) {
+            return;
+        }
+
+        const diff = scrollHeight - lastHeight.current;
+        scrollElement?.scrollTo({ top: scrollY + diff });
+
+        lastHeight.current = scrollHeight;
+    }, [cachedItems, virtualizer, scrollElement]);
+
+    React.useEffect(() => {
+        if (!cachedItems.length) {
+            setCachedItems(items);
+            return;
+        }
+
+        const newItems = _.differenceBy(items, cachedItems, "id");
+        setItemsToMeasure(newItems);
+    }, [items, cachedItems]);
+
+    const handleHeightMeasured = React.useCallback((h: number, item: TimelineItem) => {
+        heightMap.current[item.id] = h;
+
+        setItemsToMeasure(prev => prev.filter(i => i.id !== item.id));
+        setCachedItems(prev => [item, ...prev]);
+    }, []);
 
     return (
-        <Root style={{ height: virtualizer.getTotalSize() }}>
+        <Root ref={measureRef} style={{ height: totalSize }}>
+            <CacheRenderer style={{ width }}>
+                {itemsToMeasure.map(item => (
+                    <TimelineItemView key={item.id} item={item} onHeightChange={h => handleHeightMeasured(h, item)} />
+                ))}
+            </CacheRenderer>
             <Content style={{ transform: `translateY(${virtualizedItems[0]?.start ?? 0}px)` }}>
                 {virtualizedItems.map(item => {
                     return (
                         <div key={item.key} data-index={item.index} ref={virtualizer.measureElement}>
-                            <TimelineItemView item={items[item.index]} />
+                            <TimelineItemView item={cachedItems[item.index]} />
                         </div>
                     );
                 })}

--- a/apps/web/src/components/Timeline/index.tsx
+++ b/apps/web/src/components/Timeline/index.tsx
@@ -3,18 +3,35 @@ import React from "react";
 import { TimelineItem } from "@services/base/timeline";
 
 import { TimelineItemView } from "@components/Timeline/Item";
-import { Root } from "@components/Timeline/index.styles";
+import { Content, Root } from "@components/Timeline/index.styles";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 export interface TimelineProps {
     items: TimelineItem[];
+    scrollElement?: HTMLElement | null;
 }
 
-export function Timeline({ items }: TimelineProps) {
+export function Timeline({ items, scrollElement }: TimelineProps) {
+    const virtualizer = useVirtualizer({
+        estimateSize: () => 200,
+        getScrollElement: () => scrollElement ?? null,
+        count: items.length,
+        getItemKey: index => items[index].id,
+    });
+
+    const virtualizedItems = virtualizer.getVirtualItems();
+
     return (
-        <Root>
-            {items.map(item => (
-                <TimelineItemView key={item.id} item={item} />
-            ))}
+        <Root style={{ height: virtualizer.getTotalSize() }}>
+            <Content style={{ transform: `translateY(${virtualizedItems[0]?.start ?? 0}px)` }}>
+                {virtualizedItems.map(item => {
+                    return (
+                        <div key={item.key} data-index={item.index} ref={virtualizer.measureElement}>
+                            <TimelineItemView item={items[item.index]} />
+                        </div>
+                    );
+                })}
+            </Content>
         </Root>
     );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,6 +1350,18 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tanstack/react-virtual@^3.0.0-beta.54":
+  version "3.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.54.tgz#755979455adf13f2584937204a3f38703e446037"
+  integrity sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==
+  dependencies:
+    "@tanstack/virtual-core" "3.0.0-beta.54"
+
+"@tanstack/virtual-core@3.0.0-beta.54":
+  version "3.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz#12259d007911ad9fce1388385c54a9141f4ecdc4"
+  integrity sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==
+
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"


### PR DESCRIPTION
Items on timeline column would be more than current maximum count (50 posts) when keep column scrolled more than 0.

It would be a huge disaster when it renders large set of posts so we need to virtualize it first.